### PR TITLE
Use new community listfile endpoint

### DIFF
--- a/luadbd/dbds.lua
+++ b/luadbd/dbds.lua
@@ -17,7 +17,7 @@ local buildMT = {
 
 local db2s = loadstring(getCached('db2.lua', function()
   local t = {}
-  local listfile = fetchHttp('https://wow.tools/casc/listfile/download/csv/unverified')
+  local listfile = fetchHttp('https://raw.githubusercontent.com/wowdev/wow-listfile/master/community-listfile.csv')
 
   for line in listfile:gmatch('[^\r\n]+') do
     local id, name = line:match('(%d+);dbfilesclient/([a-z0-9-_]+).db2')


### PR DESCRIPTION
As wow.tools is now in read-only mode this needs updating lest I spend another 30 minutes getting confused at why wowcig isn't working.